### PR TITLE
port1.0: Implement use_xcode flag

### DIFF
--- a/doc/portfile.7
+++ b/doc/portfile.7
@@ -1588,6 +1588,19 @@ Target passed to
 .br
 .Sy Example:
 .Dl build.target all-src
+.It Ic use_xcode
+Specifies dependency on Xcode compilers. Restricts Xcode compilers on trace
+mode when set to no. The default changes to yes when build.type is set to
+Xcode (e.g., xcode 1.0 PortGroup).
+.br
+.Sy Type:
+.Em yes no
+.br
+.Sy Default:
+.Em no
+.br
+.Sy Example:
+.Dl use_xcode yes
 .El
 .Sh DESTROOT OPTIONS
 Execute necessary commands to install into a temporary destination root

--- a/src/port1.0/portbuild.tcl
+++ b/src/port1.0/portbuild.tcl
@@ -48,6 +48,7 @@ options build.asroot \
         use_parallel_build
 commands build
 # defaults
+default build.env {[get_default_env]}
 default build.asroot no
 default build.dir {${worksrcpath}}
 default build.cmd {[portbuild::build_getmaketype]}

--- a/src/port1.0/portconfigure.tcl
+++ b/src/port1.0/portconfigure.tcl
@@ -138,7 +138,7 @@ default compiler.fortran_fallback    {[portconfigure::get_fortran_fallback]}
 # define options
 commands configure autoreconf automake autoconf xmkmf
 # defaults
-default configure.env       ""
+default configure.env       {[get_default_env]}
 default configure.pre_args  {--prefix=${prefix}}
 default configure.cmd       ./configure
 default configure.nice      {${buildnicevalue}}

--- a/src/port1.0/portdestroot.tcl
+++ b/src/port1.0/portdestroot.tcl
@@ -52,6 +52,7 @@ commands destroot
 
 # Set defaults
 default destroot.asroot no
+default destroot.env {[get_default_env]}
 default destroot.dir {${build.dir}}
 default destroot.cmd {${build.cmd}}
 default destroot.pre_args {[portdestroot::destroot_getargs]}

--- a/src/port1.0/portfetch.tcl
+++ b/src/port1.0/portfetch.tcl
@@ -607,11 +607,20 @@ proc portfetch::fetch_addfilestomap {filemapname} {
     }
 }
 
+# Utility function to error out if Xcode is needed
+proc portfetch::checkxcode {} {
+    global use_xcode developer_dir
+    if {$use_xcode eq "yes" && $developer_dir eq ""} {
+        return -code error "This port requires Xcode, which was not found on your system."
+    }
+}
+
 # Initialize fetch target and call checkfiles.
 proc portfetch::fetch_init {args} {
     variable fetch_urls
 
     portfetch::checkfiles fetch_urls
+    portfetch::checkxcode
 }
 
 proc portfetch::fetch_start {args} {

--- a/src/port1.0/portfetch.tcl
+++ b/src/port1.0/portfetch.tcl
@@ -610,7 +610,7 @@ proc portfetch::fetch_addfilestomap {filemapname} {
 # Utility function to error out if Xcode is needed
 proc portfetch::checkxcode {} {
     global use_xcode developer_dir
-    if {$use_xcode eq "yes" && $developer_dir eq ""} {
+    if {$use_xcode eq "yes" && $xcodeversion eq "none"} {
         return -code error "This port requires Xcode, which was not found on your system."
     }
 }

--- a/src/port1.0/portmain.tcl
+++ b/src/port1.0/portmain.tcl
@@ -56,7 +56,7 @@ options prefix name version revision epoch categories maintainers \
         supported_archs depends_skip_archcheck installs_libs \
         license_noconflict copy_log_files \
         compiler.cpath compiler.library_path \
-        add_users
+        add_users use_xcode
 
 proc portmain::check_option_integer {option action args} {
     if {$action eq "set" && ![string is wideinteger -strict $args]} {
@@ -153,6 +153,14 @@ set egid [getegid]
 
 default worksymlink {[file normalize [file join $portpath work]]}
 default distpath {[file normalize [file join $portdbpath distfiles ${dist_subdir}]]}
+
+default use_xcode {[portmain::get_default_use_xcode]}
+proc portmain::get_default_use_xcode {} {
+    if {[option build.type] eq "xcode"} {
+        return yes
+    }
+    return no
+}
 
 proc portmain::main {args} {
     return 0

--- a/src/port1.0/portutil.tcl
+++ b/src/port1.0/portutil.tcl
@@ -508,6 +508,17 @@ proc default_check {optionName index op} {
     }
 }
 
+# get_default_env
+# Unless port is Xcode dependent, returns env which sets developer_dir to
+# Command Line Tools
+proc get_default_env {} {
+    global use_xcode
+    if {$use_xcode eq "yes"} {
+        return ""
+    }
+    return "DEVELOPER_DIR=/Library/Developer/CommandLineTools"
+}
+
 ##
 # Filter options which take strings removing indent to ease Portfile writing
 proc handle_option_string {option action args} {


### PR DESCRIPTION
To my understanding, MacPorts runs fine using only the Command Line Tools and this has been a problem for quite some time. In this PR, as part of the GSOC program, I have implemented several changes as the first step in providing a smooth experience of using MacPorts without Xcode:

1. In addition to the `port 1.0` PortGroup, maintainers can declare Xcode dependency using a new Portfile option `use_xcode`
2. Unless ports declare Xcode dependency:
    - Default ‘DEVELOPER_DIR’ to point Command Line Tools. Thus, shim Xcode binaries such as /usr/bin/clang and /usr/bin/gcc will point to Command Line Tools instead of Xcode. This will ensure all Xcode-independent ports have reproducible builds
    - Installing/building with trace mode will hide the Xcode installation, so MacPorts can fail builds for ports that actually need Xcode but are not declared as such. This will help maintainers identify Xcode dependency.
3. Error out in the `fetch` phase when users try to install Xcode-dependent ports without installing Xcode (if `$xcodeversion eq "none"`)

Relevant:
- https://trac.macports.org/ticket/35045
- https://trac.macports.org/ticket/58016

Thank you.
